### PR TITLE
added automated message to be sent to new contributors

### DIFF
--- a/.github/workflows/hello-msg-new-contributors.yml
+++ b/.github/workflows/hello-msg-new-contributors.yml
@@ -1,0 +1,13 @@
+name: Auto message for PR's and Issues
+# description: Automatically send hello message to the first PR and Issue for new contributor.
+on: [pull_request, issues]
+jobs:
+  build:
+    name: Hello new contributor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: "Hey, thank you for opening your first Issue! 🙂 While an Oraculi team member takes a look at your issue we would like to invite you to join our official Discord server, where you can interact directly with other contributors and Oraculi team members. Link here: https://discord.oraculi.io"
+          pr-message: "Hey, thank you for opening your Pull Request !  While an Oraculi team member takes a look at your PR we would like to invite you to join our official Discord server, where you can interact directly with other contributors and Oraculi team members. Link here: https://discord.oraculi.io"


### PR DESCRIPTION
This GitHub actions automation will run a workflow that will generate a welcome message that will invite a user who either opened an issue or a PR to join the Oraculi Discord server.