### PR TITLE
only trigger workflow on opened issues and PRs

### DIFF
--- a/.github/workflows/hello-msg-new-contributors.yml
+++ b/.github/workflows/hello-msg-new-contributors.yml
@@ -1,6 +1,12 @@
 name: Auto message for PR's and Issues
 # description: Automatically send hello message to the first PR and Issue for new contributor.
-on: [pull_request, issues]
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
 jobs:
   build:
     name: Hello new contributor


### PR DESCRIPTION
Correction to the workflow to exclude all other Issue and PR triggers, only acting now on opened action